### PR TITLE
fix(vim): Enable cmd + c in vim

### DIFF
--- a/home/.vimrc
+++ b/home/.vimrc
@@ -10,7 +10,6 @@ filetype plugin on
 " Indicate fast terminal conn for faster redraw
 set ttyfast
 " Indicate terminal type for mouse codes
-set mouse=a
 set ttymouse=xterm2
 " Speedup scrolling
 set ttyscroll=3


### PR DESCRIPTION
```vimrc
set mouse=a
```

を有効にすると、選択範囲を cmd + c してもclipboardにコピーされない。

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yyoshiki41/dotfiles/2)
<!-- Reviewable:end -->
